### PR TITLE
Get Steam path from registry, remove duplicated backslash

### DIFF
--- a/MoreEffectiveTransfer.csproj
+++ b/MoreEffectiveTransfer.csproj
@@ -35,7 +35,8 @@
   <PropertyGroup>
     <CitiesSkylinesInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 255710', 'InstallLocation', null, RegistryView.Registry64, RegistryView.Registry32))\</CitiesSkylinesInstallPath>
     <!-- <CitiesSkylinesModsPath>$(LOCALAPPDATA)\Colossal Order\Cities_Skylines\Addons\Mods\</CitiesSkylinesModsPath>-->
-    <CitiesSkylinesModsPath>$(CitiesSkylinesInstallPath)..\..\workshop\content\255710\1680840913\</CitiesSkylinesModsPath>
+    <SteamInstallPath>$([MSBuild]::GetRegistryValueFromView('HKEY_CURRENT_USER\Software\Valve\Steam', 'SteamPath', null, RegistryView.Registry64, RegistryView.Registry32))\</SteamInstallPath>
+    <CitiesSkylinesModsPath>$(SteamInstallPath)SteamApps\workshop\content\255710\1680840913\</CitiesSkylinesModsPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
@@ -98,7 +99,7 @@
     </ItemGroup>
     <!-- <Message Text="Ensuring @(OutputFiles) are in $(CitiesSkylinesModsPath)$(SolutionName)\%(RecursiveDir)" Importance="high" />-->
     <!-- <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(CitiesSkylinesModsPath)$(SolutionName)\%(RecursiveDir)" ContinueOnError="false" OverwriteReadOnlyFiles="true" />-->
-    <Message Text="Ensuring @(OutputFiles) are in $(CitiesSkylinesModsPath)\%(RecursiveDir)" Importance="high" />
-    <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(CitiesSkylinesModsPath)\%(RecursiveDir)" ContinueOnError="false" OverwriteReadOnlyFiles="true" />
+    <Message Text="Ensuring @(OutputFiles) are in $(CitiesSkylinesModsPath)%(RecursiveDir)" Importance="high" />
+    <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(CitiesSkylinesModsPath)%(RecursiveDir)" ContinueOnError="false" OverwriteReadOnlyFiles="true" />
   </Target>
 </Project>


### PR DESCRIPTION
As discussed in https://github.com/pcfantasy/MoreEffectiveTransfer/pull/5.

I've tested that the build files end up in the correct place, i.e. on my PC:
C:\Steam\SteamApps\workshop\content\255710\1680840913